### PR TITLE
Allow inviting as resource (support for CiviResource)

### DIFF
--- a/CRM/Eventinvitation/Form/Task/ContactSearch.php
+++ b/CRM/Eventinvitation/Form/Task/ContactSearch.php
@@ -66,6 +66,10 @@ class CRM_Eventinvitation_Form_Task_ContactSearch extends CRM_Contact_Form_Task
                     'api' => [
                         'params' => [
                             'entity_table' => 'civicrm_event',
+                            // Filter for contact resources only.
+                            'resource_type_id' => [
+                                'IN' => array_keys(CRM_Resource_Types::getForEntityTable('civicrm_contact'))
+                            ],
                             'limit' => 0,
                         ]
                     ]

--- a/CRM/Eventinvitation/Object/RunnerData.php
+++ b/CRM/Eventinvitation/Object/RunnerData.php
@@ -28,6 +28,8 @@ class CRM_Eventinvitation_Object_RunnerData extends CRM_Eventinvitation_Object_B
     /** @var string $participantRoleId */
     public $participantRoleId;
 
+    public $resourceDemandId;
+
     /** @var string $templateId */
     public $templateId;
 

--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -60,7 +60,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
             $transaction = new CRM_Core_Transaction();
 
             try {
-                $participantId = $this->setParticipantToInvited($contactId);
+                $participantId = $this->setParticipantToInvited($contactId, $this->runnerData->resourceDemandId);
                 $templateTokens = $this->getTemplateTokens($participantId);
                 $this->processContact($contactId, $templateTokens);
             } catch (Exception $error) {
@@ -89,8 +89,9 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
      * @return int
      * @throws \CiviCRM_API3_Exception
      */
-    protected function setParticipantToInvited(string $contactId): int
+    protected function setParticipantToInvited(string $contactId, $resourceDemandId = null): int
     {
+        // TODO: Check for and pass $resourceDemandId for invitations as resource.
         // check if there is/are already existing participants
         $existing_participant = civicrm_api3(
             'Participant',

--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -14,6 +14,7 @@
 | written permission from the original author(s).        |
 +-------------------------------------------------------*/
 
+use Civi\Api4\Participant;
 use CRM_Eventinvitation_ExtensionUtil as E;
 use chillerlan\QRCode\QRCode;
 
@@ -92,7 +93,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
     protected function setParticipantToInvited(string $contactId): int
     {
         // check if there is/are already existing participants
-        $existing_participant = \Civi\Api4\Participant::get(FALSE)
+        $existing_participant = Participant::get(FALSE)
             ->addWhere('event_id', '=', $this->runnerData->eventId)
             ->addWhere('contact_id', '=', $contactId);
         // When inviting as resources (de.systopia.resourceevent), filter for role and resource demand.
@@ -113,11 +114,12 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
 
         } else {
             // if there isn't one: create
-            $new_participant = \Civi\Api4\Participant::create(FALSE)
+            $new_participant = Participant::create(false)
                 ->addValue('event_id', $this->runnerData->eventId)
                 ->addValue('contact_id', $contactId)
                 ->addValue('status_id:name', CRM_Eventinvitation_Upgrader::PARTICIPANT_STATUS_INVITED_NAME)
-                ->addValue('role_id', $this->runnerData->participantRoleId);
+                ->addValue('role_id', $this->runnerData->participantRoleId)
+                ->addValue('register_date', date('Y-m-d H:i:s'));
             // When inviting as resource (de.systopia.resourceevent), add resource demand value.
             if (!empty($this->runnerData->resourceDemandId)) {
                 $new_participant

--- a/README.md
+++ b/README.md
@@ -58,14 +58,24 @@ variables:
 ### Using a Drupal endpoint
 
 If you are using a Drupal endpoint based on CiviRemote, visit the extension's
-settings page, tickt the custom URL box and
-enter `https://yourpublicfrontend.org/civiremote/event/register/{token}` as the
-custom url.
+settings page, tickt the custom URL box and enter one of the following as the
+custom url, depending on your configuration and, if applicable, custom
+implementations:
+* `https://yourpublicfrontend.org/civiremote/event/register/{token}`
+    With the *register* endpoint, the user's reaction to the invitation is being
+    processed as a registration, i.e. they must have the permission to register,
+    which includes that registration for the event is still open and no other
+    restrictions are in effect.
+* `https://yourpublicfrontend.org/civiremote/event/update/{token}`
+    With the *update* endpoint, the user's reaction to the invitation is being
+    processed as an update to a registration (which, technically speaking,
+    already exists with the status *Invited*), i.e. they must have the
+    permission to update own registrations.
 
-On your public Drupal system,
-install [CiviRemote](https://github.com/systopia/civiremote), add a CiviRemote
-profile (`/admin/config/cmrf/profiles`) and
-connector (`/admin/config/cmrf/connectors`) if you have not done so yet.
+On your public Drupal system, install
+[CiviRemote](https://github.com/systopia/civiremote), add a CiviRemote profile
+(`/admin/config/cmrf/profiles`) and connector (`/admin/config/cmrf/connectors`)
+if you have not done so yet.
 
 ## Usage
 

--- a/js/invite-resource.js
+++ b/js/invite-resource.js
@@ -1,0 +1,65 @@
+/*-------------------------------------------------------+
+| SYSTOPIA Event Invitation                              |
+| Copyright (C) 2022 SYSTOPIA                            |
+| Author: J. Schuppe (schuppe@systopia.de)               |
++--------------------------------------------------------+
+| This program is released as free software under the    |
+| Affero GPL license. You can redistribute it and/or     |
+| modify it under the terms of this license which you    |
+| can read by viewing the included agpl.txt or online    |
+| at www.gnu.org/licenses/agpl.html. Removal of this     |
+| copyright header is strictly prohibited without        |
+| written permission from the original author(s).        |
++-------------------------------------------------------*/
+
+(function ($, _, ts) {
+  $(document).ready(function () {
+    let $form = $('form.CRM_Eventinvitation_Form_Task_ContactSearch');
+    let $participant_roles = $form.find('[name="participant_roles"]');
+    let $resource_demand_id = $form.find('[name="resource_demand_id"]');
+
+    // restrict the resource demand field to the selected event.
+    $form.find('[name="event"]')
+        .on('change', function() {
+          let api_params = $resource_demand_id.data('api-params');
+          api_params.params.entity_id = $(this).val();
+          if ($resource_demand_id.data('event_id') !== parseInt($(this).val())) {
+            $resource_demand_id
+              .data('event_id', null)
+              .val('').trigger('change');
+          }
+        });
+
+    $resource_demand_id.on('change', function () {
+          let $resource_demand_id = $(this);
+          if ($resource_demand_id.val()) {
+            // Set the event field according to the selected resource demand.
+            CRM.api4(
+              'ResourceDemand',
+              'get',
+              {where: [['id', '=', $resource_demand_id.val()]]}
+            ).then(function (results) {
+              $resource_demand_id.data('event_id', results[0].entity_id);
+              $form.find('[name="event"]')
+                .val(results[0].entity_id)
+                .trigger('change');
+            });
+
+            // Set the participant role field to the resource role.
+            $participant_roles
+              .val(CRM.vars.eventinvitation.resource_role_id).trigger('change')
+              .find('option[value=""]').show();
+          }
+          else {
+            $participant_roles
+              .val($participant_roles.find('option:first').val())
+          }
+        });
+
+    $participant_roles.on('change', function() {
+      if (parseInt($(this).val()) !== CRM.vars.eventinvitation.resource_role_id) {
+        $resource_demand_id.val('').trigger('change');
+      }
+    });
+  });
+})(CRM.$, CRM._, CRM.ts('de.systopia.eventinvitation'));

--- a/templates/CRM/Eventinvitation/Form/Task/ContactSearch.tpl
+++ b/templates/CRM/Eventinvitation/Form/Task/ContactSearch.tpl
@@ -18,6 +18,28 @@
         <div class="content">{$form.event.html}</div>
         <div class="clear"></div>
     </div>
+
+    {if $form.resource_demand_id}
+      <div class="help">
+          {ts 1=$resource_role_label}For inviting contacts as resources for the selected event, select the role %1 and choose the resource demand they should be assigned to.{/ts}
+      </div>
+
+      <div class="crm-section">
+        <div class="label">{$form.resource_demand_id.label}</div>
+        <div class="content">
+            {$form.resource_demand_id.html}
+            <div class="description">{ts}A resource demand is mandatory when inviting contacts as resources.{/ts}</div>
+        </div>
+        <div class="clear"></div>
+      </div>
+    {/if}
+
+    <div class="crm-section">
+      <div class="label">{$form.participant_roles.label}</div>
+      <div class="content">{$form.participant_roles.html}</div>
+      <div class="clear"></div>
+    </div>
+
     <div class="crm-section">
         {capture assign=label_help}{ts}Template Help{/ts}{/capture}
         <div class="label">{$form.template.label}{help id="id-template-tokens" title=$label_help}</div>
@@ -32,11 +54,6 @@
     <div class="crm-section">
         <div class="label">{$form.email_sender.label}</div>
         <div class="content">{$form.email_sender.html}</div>
-        <div class="clear"></div>
-    </div>
-    <div class="crm-section">
-        <div class="label">{$form.participant_roles.label}</div>
-        <div class="content">{$form.participant_roles.html}</div>
         <div class="clear"></div>
     </div>
 


### PR DESCRIPTION
[CiviResource](https://github.com/systopia/de.systopia.resource) and specifically its event-related implementation [de.systopia.resourceevent](https://github.com/systopia/de.systopia.resourceevent) provide a participant role and associated synchronisation for human resources being assigned for specific resource demands on CiviCRM events.

This PR allows inviting contacts as a resource, i.e. giving them the special *Human Resource* participant role and synchronising with CiviResource data structure when the invitation is being accepted.

For this purpose, the existing *Invite participant* contact search task is being dynamically extended when the CiviResource extensions are installed, adding the following features:

* autocomplete search field for resource demands on events (restricted to a potentially previously selected event)
* automatically setting the event field to the corresponding event if a resource demand was selected first
* automatically setting the participant role to *Human Resource* if a resource demand was selected
* requiring a resource demand when the participant role was set to *Human Resource*

Synchronisation of participant objects with the *Human Resource* role and CiviResource assignments to resource demands re being processed by CiviResource itself and is thus not needed as part of this PR.