### PR TITLE
Show active Roles only

### DIFF
--- a/CRM/Eventinvitation/Form/Task/ContactSearch.php
+++ b/CRM/Eventinvitation/Form/Task/ContactSearch.php
@@ -381,6 +381,7 @@ class CRM_Eventinvitation_Form_Task_ContactSearch extends CRM_Contact_Form_Task
             'get',
             [
                 'option_group_id' => 'participant_role',
+                'is_active' => TRUE,
                 'option.limit' => 0,
                 'return' => 'value,label',
             ]


### PR DESCRIPTION
Currently when showing the roles, it shows all the roles. They should be filtered by only active ones.