### PR TITLE
Do not send to contacts with (bounce-related) on_hold email

### DIFF
--- a/CRM/Eventinvitation/Form/Task/ContactSearch.php
+++ b/CRM/Eventinvitation/Form/Task/ContactSearch.php
@@ -183,7 +183,7 @@ class CRM_Eventinvitation_Form_Task_ContactSearch extends CRM_Contact_Form_Task
         $contactIds = $this->_contactIds;
 
         if (!$shallBePdfs && !$this->contactsHaveEmails($contactIds)) {
-            $this->_errors[self::PDFS_INSTEAD_OF_EMAILS_ELEMENT_NAME] = E::ts("There are contacts that have no e-mail address.");
+            $this->_errors[self::PDFS_INSTEAD_OF_EMAILS_ELEMENT_NAME] = E::ts("There are contacts that have no usable e-mail address.");
         }
 
         if ($this->contactsHaveNotInvitedParticipants($contactIds, $eventId, $participantRoleId)) {
@@ -221,6 +221,7 @@ class CRM_Eventinvitation_Form_Task_ContactSearch extends CRM_Contact_Form_Task
                         contact.id = email.contact_id
             WHERE
                 email.contact_id IN ($contactIdsAsCommaSeparatedList)
+                AND email.on_hold = 0
                 AND contact.do_not_email = 0
                 AND contact.is_deleted = 0
         ) AS distinct_contact

--- a/CRM/Eventinvitation/Queue/Runner/EmailSender.php
+++ b/CRM/Eventinvitation/Queue/Runner/EmailSender.php
@@ -51,16 +51,24 @@ class CRM_Eventinvitation_Queue_Runner_EmailSender extends CRM_Eventinvitation_Q
                 'return' => 'display_name,email'
             ]
         );
+        $email = \Civi\Api4\Email::get(FALSE)
+            ->selectRowCount()
+            ->addWhere('contact_id', '=', $contactId)
+            ->addWhere('email', '=', $contactData['email'])
+            ->addWhere('on_hold', '=', 0)
+            ->execute()
+            ->count();
+        if ($email >= 1) {
+            $emailData = [
+                'id' => $this->runnerData->templateId,
+                'toName' => $contactData['display_name'],
+                'toEmail' => $contactData['email'],
+                'from' => $this->emailSender,
+                'contactId' => $contactId,
+                'tplParams' => $templateTokens,
+            ];
 
-        $emailData = [
-            'id' => $this->runnerData->templateId,
-            'toName' => $contactData['display_name'],
-            'toEmail' => $contactData['email'],
-            'from' => $this->emailSender,
-            'contactId' => $contactId,
-            'tplParams' => $templateTokens,
-        ];
-
-        civicrm_api3('MessageTemplate', 'send', $emailData);
+            civicrm_api3('MessageTemplate', 'send', $emailData);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3.

This will have to be cherry-picked for `1.0.x` as well.