### PR TITLE
Bugfix custom url

### DIFF
--- a/CRM/Eventinvitation/Form/Settings.php
+++ b/CRM/Eventinvitation/Form/Settings.php
@@ -31,15 +31,15 @@ class CRM_Eventinvitation_Form_Settings extends CRM_Core_Form
         $this->add(
             'checkbox',
             self::LINK_TARGET_IS_CUSTOM_FORM_NAME,
-            E::ts('Enable custom endpoint')
+            E::ts('Use a custom registration endpoint')
         );
 
         $this->add(
             'text',
             self::CUSTOM_LINK_TARGET_FORM_NAME,
-            E::ts('Custom link target URL:'),
+            E::ts('Url of custom registration endpoint:'),
             ['class' => 'huge'],
-            true
+            false
         );
         $this->addRule(
             self::CUSTOM_LINK_TARGET_FORM_NAME,

--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -150,8 +150,8 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
         $link = '';
         if (
             is_array($settings)
-            && array_key_exists(CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME, $settings)
-            && array_key_exists(CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME, $settings)
+            && ! empty($settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME])
+            && ! empty($settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME])
         ) {
             // get the link
             $link = $settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME];

--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -150,8 +150,10 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
         $link = '';
         if (
             is_array($settings)
-            && ! empty($settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME])
-            && ! empty($settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME])
+            && isset($settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME])
+            && 1 == $settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME]
+            && isset($settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME])
+            && '' !== $settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME]
         ) {
             // get the link
             $link = $settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME];

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 This extension allows you to invite contacts in CiviCRM to an event and provides
 a simple feedback form where contacts can choose whether they can attend or not.
-You can invite contacts via email or letter, both can include a personalized
-link, if you use a letter, the link can be presented as a QR link.
+You can invite contacts via email or letter. Both can include a personalized
+invitation link. If you use a letter, the link can be presented as a QR link.
 
 Currently, the extension only provides a very basic built-in feedback form. This
-form currently only features a simple "register" button which will set the
-participant's status to confirmed so Weẃ encourage you to generate an external
-landing page / endpoint for the form. (seer below) For Drupal you will most
-likely want to use
+form only features a simple "register" button which will set the participant's
+status to confirmed. We encourage you to generate an external landing page or
+endpoint for the form (see below). 
+
+For Drupal you will most likely want to use
 the [CiviRemote Drupal module](https://github.com/systopia/civiremote) which
 includes a lot of pre-built features.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ variables:
 * `{$qr_event_invite_code_data}` - generates a unique link for the participant
   presented as an QR Code that can be html formatted as an image
 
+*Remark*: if an event-invitation is being generated as pdf-file from a particular 
+message template, then only the *Html*-section of that template will be taken into
+account. The *Plain-Text* section will be ignored. In that case, all tokens should
+be placed into the *Html* section. *Plain-Text* only message template will result
+in empty pdf-files.
+
 ### Using a Drupal endpoint
 
 If you are using a Drupal endpoint based on CiviRemote, visit the extension's

--- a/l10n/de.systopia.eventinvitation.pot
+++ b/l10n/de.systopia.eventinvitation.pot
@@ -69,11 +69,11 @@ msgid "Event Invitation Configuration"
 msgstr ""
 
 #: CRM/Eventinvitation/Form/Settings.php
-msgid "Enable custom endpoint"
+msgid "Use a custom registration endpoint"
 msgstr ""
 
 #: CRM/Eventinvitation/Form/Settings.php
-msgid "Custom link target URL:"
+msgid "Url of custom registration endpoint:"
 msgstr ""
 
 #: CRM/Eventinvitation/Form/Settings.php

--- a/l10n/de_DE/LC_MESSAGES/eventinvitation.po
+++ b/l10n/de_DE/LC_MESSAGES/eventinvitation.po
@@ -76,12 +76,12 @@ msgid "Event Invitation Configuration"
 msgstr "Konfiguration Veranstaltungseinladungen"
 
 #: CRM/Eventinvitation/Form/Settings.php
-msgid "Enable custom endpoint"
-msgstr "Benutzerdefinierte URL"
+msgid "Use a custom registration endpoint"
+msgstr "Benutzerdefinierte URL verwenden"
 
 #: CRM/Eventinvitation/Form/Settings.php
-msgid "Custom link target URL:"
-msgstr "Ziel-URL der Anmeldung"
+msgid "Url of custom registration endpoint:"
+msgstr "Benutzerdefinierte-URL der Anmeldung:"
 
 #: CRM/Eventinvitation/Form/Settings.php
 msgid "Enter a valid web address beginning with 'http://' or 'https://'."

--- a/l10n/de_DE/LC_MESSAGES/eventinvitation.po
+++ b/l10n/de_DE/LC_MESSAGES/eventinvitation.po
@@ -81,7 +81,7 @@ msgstr "Benutzerdefinierte URL verwenden"
 
 #: CRM/Eventinvitation/Form/Settings.php
 msgid "Url of custom registration endpoint:"
-msgstr "Benutzerdefinierte-URL der Anmeldung:"
+msgstr "Benutzerdefinierte URL der Anmeldung:"
 
 #: CRM/Eventinvitation/Form/Settings.php
 msgid "Enter a valid web address beginning with 'http://' or 'https://'."

--- a/templates/CRM/Eventinvitation/Form/Settings.hlp
+++ b/templates/CRM/Eventinvitation/Form/Settings.hlp
@@ -14,9 +14,14 @@
 
 {crmScope extensionKey='de.systopia.eventinvitation'}
 
-{htxt id='id-external_link'}
-  <p>{ts}You can add a link here, to use an external checkin page, rather than the built-in one.{/ts}</p>
-  <p>{ts}The link <strong>has to</strong> contain the <code>&#123;token&#125;</code> which will be replaced wit the generated code.{/ts}</p>
+{htxt id='id-link-target-enabled'}
+  <p>{ts}Here you can enable the use of an external registration-page.{/ts}</p>
+  <p>{ts}If this box is not checked but a Url has been provided, then the Url will be ignored and the built-in registration-page will be used.{/ts}</p>
+{/htxt}
+
+{htxt id='id-link-target'}
+  <p>{ts}Here you can add a Url, in order to use an external registration-page, rather than the built-in one.{/ts}</p>
+  <p>{ts}The provided Url <strong>has to</strong> contain the <code>&#123;token&#125;</code> which will be replaced by the generated code.{/ts}</p>
 {/htxt}
 
 {htxt id='id-token-timeout'}

--- a/templates/CRM/Eventinvitation/Form/Settings.hlp
+++ b/templates/CRM/Eventinvitation/Form/Settings.hlp
@@ -16,12 +16,12 @@
 
 {htxt id='id-link-target-enabled'}
   <p>{ts}Here you can enable the use of an external registration-page.{/ts}</p>
-  <p>{ts}If this box is not checked but a Url has been provided, then the Url will be ignored and the built-in registration-page will be used.{/ts}</p>
+  <p>{ts}If this box is not checked but a url has been provided, then that url will be ignored and the built-in registration-page will be used.{/ts}</p>
 {/htxt}
 
 {htxt id='id-link-target'}
-  <p>{ts}Here you can add a Url, in order to use an external registration-page, rather than the built-in one.{/ts}</p>
-  <p>{ts}The provided Url <strong>has to</strong> contain the <code>&#123;token&#125;</code> which will be replaced by the generated code.{/ts}</p>
+  <p>{ts}Here you can add a url, in order to use an external registration-page, rather than the built-in one.{/ts}</p>
+  <p>{ts}The provided url <strong>has to</strong> contain the <code>&#123;token&#125;</code> which will be replaced by the generated code.{/ts}</p>
 {/htxt}
 
 {htxt id='id-token-timeout'}


### PR DESCRIPTION
This PR contains several changes

- fixed typos in README.md
- a new remark paragraph in README.md about empty generated pdf files when using plain-text only message templates
- rephrased form labels and help text of form elements

- fixed bug where help text of form elements has not been displayed when clicking on the small blue question mark
- fixed bug where a custom url to a registration page was always used once it had been entered, no matter if the corresponding checkbox was disabled or if url field was cleared afterwards