### PR TITLE
fixed api call on uninstall

### DIFF
--- a/CRM/Eventinvitation/Upgrader.php
+++ b/CRM/Eventinvitation/Upgrader.php
@@ -55,6 +55,7 @@ class CRM_Eventinvitation_Upgrader extends CRM_Extension_Upgrader_Base
             'ParticipantStatusType',
             'get',
             [
+                'sequential' => 1,
                 'name' => self::PARTICIPANT_STATUS_INVITED_NAME
             ]
         );
@@ -64,7 +65,7 @@ class CRM_Eventinvitation_Upgrader extends CRM_Extension_Upgrader_Base
                 'ParticipantStatusType',
                 'delete',
                 [
-                    'id' => $apiResult['values']['id']
+                    'id' => $apiResult['values'][0]['id']
                 ]
             );
         }


### PR DESCRIPTION
Hello @bjendres, 

When trying to uninstall the extension, I ran into the following error: 

```
"error_code" => "mandatory_missing"
"entity" => "ParticipantStatusType"
"action" => "delete"
"is_error" => 1
"error_message" => "Mandatory key(s) missing from params array: id"
```

This PR includes a fix to handle the issue during the uninstall process. 
Sharing in case it’s useful.

I’ve tested it on CiviCRM 5.69 with Drupal 9.

Best regards, 