### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Eventinvitation/Form/Task/ContactSearch.php
+++ b/CRM/Eventinvitation/Form/Task/ContactSearch.php
@@ -260,7 +260,7 @@ class CRM_Eventinvitation_Form_Task_ContactSearch extends CRM_Contact_Form_Task
      * @return bool
      *   true if the template contains one of the tokens
      *
-     * @throws \CiviCRM_API3_Exception
+     * @throws \CRM_Core_Exception
      */
     private function templateHasCodeToken(string $templateId): bool
     {

--- a/CRM/Eventinvitation/Queue/Runner/EmailSender.php
+++ b/CRM/Eventinvitation/Queue/Runner/EmailSender.php
@@ -39,7 +39,7 @@ class CRM_Eventinvitation_Queue_Runner_EmailSender extends CRM_Eventinvitation_Q
      * @param array $templateTokens
      *   tokens
      *
-     * @throws \CiviCRM_API3_Exception
+     * @throws \CRM_Core_Exception
      */
     protected function processContact($contactId, $templateTokens)
     {

--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -46,7 +46,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
      * @param array $templateTokens
      *   tokens
      *
-     * @throws \CiviCRM_API3_Exception
+     * @throws \CRM_Core_Exception
      */
     protected abstract function processContact($contactId, $templateTokens);
 
@@ -88,7 +88,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
      *   the contact that should be invited
      *
      * @return int
-     * @throws \CiviCRM_API3_Exception
+     * @throws \CRM_Core_Exception
      */
     protected function setParticipantToInvited(string $contactId): int
     {
@@ -187,7 +187,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job
             if (!empty($this->runnerData->eventId)) {
                 try {
                     $event_data = civicrm_api3('Event', 'getsingle', ['id' => $this->runnerData->eventId]);
-                } catch (CiviCRM_API3_Exception $ex) {
+                } catch (CRM_Core_Exception $ex) {
                     $event_data = []; // don't look up again
                     Civi::log()->error("Error loading event [{$this->runnerData->eventId}]: " . $ex->getMessage());
                 }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.