### PR TITLE
Fix comparison for link generation

### DIFF
--- a/CRM/Eventinvitation/Queue/Runner/Job.php
+++ b/CRM/Eventinvitation/Queue/Runner/Job.php
@@ -152,7 +152,7 @@ abstract class CRM_Eventinvitation_Queue_Runner_Job {
     if (
         is_array($settings)
         && isset($settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME])
-        && 1 === $settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME]
+        && (bool) $settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME]
         && isset($settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME])
         && '' !== $settings[CRM_Eventinvitation_Form_Settings::CUSTOM_LINK_TARGET_FORM_NAME]
     ) {


### PR DESCRIPTION
In #22 an equal comparison (`1 == $settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME]`) was replaced by a same comparison (`1 === $settings[CRM_Eventinvitation_Form_Settings::LINK_TARGET_IS_CUSTOM_FORM_NAME]`) resulting in the comparison being always false because the stored value is either an empty string or `'1'`. Thus, a custom a link was never used.

systopia-reference: 35049